### PR TITLE
remove: graphql-request lib and use fetch instead

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@graphql-codegen/typescript-graphql-request": "^6.2.0",
         "graphql": "^16.10.0",
-        "graphql-request": "^6.1.0",
         "graphql-tag": "^2.12.6",
         "typescript": "^5.8.2"
       },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "@graphql-codegen/typescript-graphql-request": "^6.2.0",
     "graphql": "^16.10.0",
-    "graphql-request": "^6.1.0",
     "graphql-tag": "^2.12.6",
     "typescript": "^5.8.2"
   }


### PR DESCRIPTION
### Summary
- Remove `graphql-request` library and use native `fetch` instead.

### Screenshots
Test passing ✅ 
<img width="505" alt="image" src="https://github.com/user-attachments/assets/48c7ae1b-3047-491d-995f-4a3a7b3ae7d3" />
