### PR TITLE
Enable raw GraphQL requests for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,33 @@ const recentTransactions = await client.query(
 console.log(recentTransactions);
 ```
 
+### Direct GraphQL Queries
+
+```typescript
+// For more complex queries, you can use direct GraphQL using client.request
+const query = `
+  query {
+    tokens(
+      limit: 5, 
+      where: { 
+        OR: [
+          {tokenType_eq: ERC20}, 
+          {tokenType_eq: ERC721}
+        ]
+      }
+    ) {
+      id
+      tokenType
+      tokenAddress
+      tokenSubID
+    }
+  }
+`;
+
+const result = await client.request(query);
+console.log(result);
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ console.log(recentTransactions);
 
 ```typescript
 // For more complex queries, you can use direct GraphQL using client.request
+// Note: Enums must be in uppercase
 const query = `
   query {
     tokens(
@@ -123,9 +124,35 @@ const query = `
   }
 `;
 
+
+
 const result = await client.request(query);
 console.log(result);
 ```
+
+```ts
+// For connection queries, we encourage you to use the `request` method with the `connection` property
+// This will return a `Connection` object with the `edges` and `pageInfo` properties
+const query = `
+  query {
+    commitmentsConnection(orderBy: id_ASC, after: "10", first: 10) {
+      edges {
+        cursor
+        node {
+          batchStartTreePosition
+        }
+      }
+      pageInfo {
+        hasNextPage
+      }
+    }
+  }
+`;
+
+const result = await client.request(query);
+console.log(result);
+```
+
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@graphql-codegen/typescript-graphql-request": "^6.2.0",
     "graphql": "^16.10.0",
-    "graphql-tag": "^2.12.6",
     "typescript": "^5.8.2"
   },
   "devDependencies": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,10 +1,11 @@
+import { QueryBuilder } from './query-builder';
 import { NetworkName, NETWORK_CONFIG, SUPPORTED_NETWORKS } from './networks';
-import { QueryIO, QueryInput, QueryOutput, FilterValue, FieldsArgs } from './types';
 
 export class SubsquidClient {
+  private queryBuilder: QueryBuilder;
   private clientUrl: string;
-
   constructor(network: NetworkName) {
+    this.queryBuilder = new QueryBuilder();
     this.clientUrl = this.getSubsquidUrlForNetwork(network);
   }
 
@@ -44,166 +45,15 @@ export class SubsquidClient {
   };
 
   /**
-   * Converts a JSON object to a GraphQL arguments string
-   * Handles enum values correctly (removes quotes from values that appear to be enums)
-   * 
-   * This method is needed for complex nested objects like 'where' filters
-   */
-  private jsonToGraphQLArgs(obj: any): string {
-    if (!obj) return '';
-
-    // Replace with a completely new implementation
-    const processObj = (obj: any): string => {
-      if (obj === null || obj === undefined) {
-        return 'null';
-      }
-
-      if (typeof obj === 'string') {
-        // Check if this is likely an enum (all uppercase with underscores and numbers)
-        if (/^[A-Z0-9_]+$/.test(obj)) {
-          return obj; // Return enum without quotes
-        } else {
-          return JSON.stringify(obj); // Return string with quotes
-        }
-      }
-
-      if (typeof obj === 'number' || typeof obj === 'boolean') {
-          return String(obj);
-      }
-
-      if (Array.isArray(obj)) {
-        const items = obj.map((item) => processObj(item)).join(', ');
-        return `[${items}]`;
-      }
-
-      if (typeof obj === 'object') {
-        const pairs = Object.entries(obj)
-          .map(([key, value]) => `${key}: ${processObj(value)}`)
-          .join(', ');
-        return `{${pairs}}`;
-      }
-  
-      return String(obj);
-    };
-
-    return processObj(obj);
-  }
-
-  /**
-   * Process a filter for a GraphQL query, handling different filter types appropriately
-   * 
-   * @param entityName - The entity being queried (e.g., 'tokens', 'commitments')
-   * @param filterName - The filter name (e.g., 'where', 'orderBy', 'limit')
-   * @param value - The filter value with appropriate type based on FilterValue
-   * @returns Formatted GraphQL argument string
-   */
-  private processFilter<K extends keyof QueryIO, F extends keyof QueryIO[K]['input']>(
-      _entityName: K,
-      filterName: F,
-      value: FilterValue<K, F>
-    ): string {
-    switch (filterName) {
-      case 'where':
-        return value ? `where: ${this.jsonToGraphQLArgs(value)}` : '';
-        
-      case 'orderBy':
-        if (Array.isArray(value) && value.length > 0) {
-          const orderByValues = value
-            .map(order => String(order).replace(/["']/g, ''))
-            .join(', ');
-          return `orderBy: [${orderByValues}]`;
-        }
-        return '';
-        
-      // All of these are `type number`
-      case 'limit':
-      case 'offset':
-      case 'first':
-        return value !== undefined ? `${String(filterName)}: ${value}` : '';
-      case 'after':
-        return value ? `after: ${JSON.stringify(value)}` : '';
-        
-      default:
-        // For any unknown filter, attempt to format it in a sensible way based on its type
-        if (value !== undefined && value !== null) {
-          if (typeof value === 'string') {
-            // Check if it's an enum value (all caps with underscores)
-            const isEnum = /^[A-Z][A-Z0-9_]*$/.test(value as string);
-            return `${String(filterName)}: ${isEnum ? value : JSON.stringify(value)}`;
-          } else if (typeof value === 'number' || typeof value === 'boolean') {
-            return `${String(filterName)}: ${value}`;
-          } else if (Array.isArray(value)) {
-            return `${String(filterName)}: ${this.jsonToGraphQLArgs(value)}`;
-          } else if (typeof value === 'object') {
-            return `${String(filterName)}: ${this.jsonToGraphQLArgs(value)}`;
-          }
-        }
-        return '';
-    }
-  }
-
-  /**
-   * Parse a single entity query from the input object
-   * 
-   * @param entityName - The entity name (e.g., 'tokens')
-   * @param filters - The filters for the entity (e.g., { fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'], limit: 5 })
-   * @returns Formatted GraphQL query string
-   */
-  private parseEntityQuery<K extends keyof QueryIO>(
-    {entityName, filters}: { entityName: K, filters: QueryIO[K]['input'] }
-  ): string {
-    // We know entity name is a key of QueryIO, force a cast type over it
-    const typedEntityName = entityName as keyof QueryIO;
-    const fields = filters.fields as FieldsArgs<typeof typedEntityName>[];
-    
-    // Check that query has actually some fields requested data, if not is not a valid gql query
-    if (!fields || !Array.isArray(fields) || fields.length === 0) {
-      throw new Error(`Query can't have empty return data for entity ${String(typedEntityName)}`);
-    }
-    
-    // Process all filter args into a formatted string for the entity query
-    const filterArgs = Object.entries(filters)
-      .filter(([ name, _value ]) => name !== 'fields') // Fields is handled separately from the rest
-      .reduce((acc: string[], [name, value]) => {
-        const argName = name as keyof QueryIO[typeof typedEntityName]['input']; // type the argument name, some queries do not allow doing where or other filters, so we need to type it
-        const argValues = value as FilterValue<typeof typedEntityName, keyof QueryIO[typeof typedEntityName]['input']>;
-        
-        // Process the filter and add it to accumulator if it's not empty
-        const processed = this.processFilter(typedEntityName, argName, argValues);
-        if (processed) acc.push(processed);
-        
-        return acc;
-      }, [])
-      .join(', ');
-    // Handle edge case: don't include empty parentheses when args is empty
-    const filtersForQuery = filterArgs ? `(${filterArgs})` : '';
-
-    const queryForEntity = `${String(entityName)}${filtersForQuery} {
-      ${fields.join('\n                ')}
-    }`;
-
-    return queryForEntity;
-  }
-    // Get strongly typed entity name
-  /**
    * Generic query method that can handle any entity type with proper type safety
    */
-  async query<T extends QueryInput>(
-    input: T & Record<Exclude<keyof T, keyof QueryInput>, never>,
-  ): Promise<QueryOutput<T>> {
+  // async query(input: string): Promise<unknown>  
+  async query(
+    input: string,
+  ): Promise<unknown> {
     try {
-      const entities = Object.entries(input);
-      const queryStr = `
-        query {
-          ${entities
-            .map(([entity, filters]) => {
-              const entityName = entity as keyof QueryIO;
-              const parsedQuery = this.parseEntityQuery({ entityName, filters });
-              return parsedQuery;
-            }).join('\n          ')}
-        }
-      `;
-      return this.request<QueryOutput<T>>(queryStr);
+      const queryStr = this.queryBuilder.build(input);
+      return this.request(queryStr);
     } catch (error) {
       console.error('Error in query', error);
       throw error;

--- a/src/client.ts
+++ b/src/client.ts
@@ -22,26 +22,33 @@ export class SubsquidClient {
   /**
    * Generic request method for GraphQL queries using fetch with type safety
    */
-  private request = async <T>(query: string): Promise<T> => {
-    const response = await fetch(this.clientUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ query }),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Network response was not ok: ${response.statusText}`);
-    }
-
-    const result = await response.json();
-
-    if (result.errors) {
-      throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
-    }
-
-    return result.data as T;
+  request = async <T>(query: string): Promise<T> => {
+    try {
+      const requestBody = JSON.stringify({ query });
+      
+      const response = await fetch(this.clientUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: requestBody,
+      });
+  
+      if (!response.ok) {
+        throw new Error(`Network response was not ok: ${response.statusText}`);
+      }
+  
+      const result = await response.json();
+  
+      if (result.errors) {
+        throw new Error(`GraphQL errors: ${JSON.stringify(result.errors)}`);
+      }
+  
+      return result.data as T;
+    } catch(error) {
+      console.error('Error in request', error);
+      throw error;
+    };
   };
 
   /**

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -1,0 +1,150 @@
+import { QueryIO, QueryInput, FilterValue, FieldsArgs } from './types';
+
+export class QueryBuilder {
+  constructor() {}
+  /**
+   * Converts a JSON object to a GraphQL arguments string
+   * Handles enum values correctly (removes quotes from values that appear to be enums)
+   * 
+   * This method is needed for complex nested objects like 'where' filters
+   */
+  jsonToGraphQLArgs(obj: any): string {
+    if (!obj) return '';
+
+    // Replace with a completely new implementation
+    const processObj = (obj: any): string => {
+      if (obj === null || obj === undefined) {
+        return 'null';
+      }
+
+      if (typeof obj === 'string') {
+        // Check if this is likely an enum (all uppercase with underscores and numbers)
+        if (/^[A-Z0-9_]+$/.test(obj)) {
+          return obj; // Return enum without quotes
+        } else {
+          return JSON.stringify(obj); // Return string with quotes
+        }
+      }
+
+      if (typeof obj === 'number' || typeof obj === 'boolean') {
+          return String(obj);
+      }
+
+      if (Array.isArray(obj)) {
+        const items = obj.map((item) => processObj(item)).join(', ');
+        return `[${items}]`;
+      }
+
+      if (typeof obj === 'object') {
+        const pairs = Object.entries(obj)
+          .map(([key, value]) => `${key}: ${processObj(value)}`)
+          .join(', ');
+        return `{${pairs}}`;
+      }
+  
+      return String(obj);
+    };
+
+    return processObj(obj);
+  }
+
+  /**
+   * Process a filter for a GraphQL query, handling different filter types appropriately
+   * 
+   * @param entityName - The entity being queried (e.g., 'tokens', 'commitments')
+   * @param filterName - The filter name (e.g., 'where', 'orderBy', 'limit')
+   * @param value - The filter value with appropriate type based on FilterValue
+   * @returns Formatted GraphQL argument string
+   */
+
+  processFilter<K extends keyof QueryIO, F extends keyof QueryIO[K]['input']>(
+      _entityName: K,
+      filterName: F,
+      value: FilterValue<K, F>
+    ): string {
+    switch (filterName) {
+      case 'where':
+        return value ? `where: ${this.jsonToGraphQLArgs(value)}` : '';
+        
+      case 'orderBy':
+        if (Array.isArray(value) && value.length > 0) {
+          const orderByValues = value
+            .map(order => String(order).replace(/["']/g, ''))
+            .join(', ');
+          return `orderBy: [${orderByValues}]`;
+        }
+        return '';
+        
+      // All of these are `type number`
+      case 'limit':
+      case 'offset':
+      case 'first':
+        return value !== undefined ? `${String(filterName)}: ${value}` : '';
+      case 'after':
+        return value ? `after: ${JSON.stringify(value)}` : '';
+        
+      default:
+        return '';
+    }
+  }
+
+  /**
+   * Parse a single entity query from the input object
+   * 
+   * @param entityName - The entity name (e.g., 'tokens')
+   * @param filters - The filters for the entity (e.g., { fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'], limit: 5 })
+   * @returns Formatted GraphQL query string
+   */
+  private parseEntityQuery<K extends keyof QueryIO>(
+    {entityName, filters}: { entityName: K, filters: QueryIO[K]['input'] }
+  ): string {
+    // We know entity name is a key of QueryIO, force a cast type over it
+    const typedEntityName = entityName as keyof QueryIO;
+    const fields = filters.fields as (FieldsArgs<typeof typedEntityName>)[];
+    
+    // Check that query has actually some fields requested data, if not is not a valid gql query
+    if (!fields || !Array.isArray(fields) || fields.length === 0) {
+      throw new Error(`Query can't have empty return data for entity ${String(typedEntityName)}`);
+    }
+    
+    const filterArgs = Object.entries(filters)
+      .filter(([ name, _value ]) => name !== 'fields') // Fields is handled separately from the rest
+      .reduce((acc: string[], [name, value]) => {
+        const argName = name as keyof QueryIO[typeof typedEntityName]['input']; // type the argument name, some queries do not allow doing where or other filters, so we need to type it
+        const argValues = value as FilterValue<typeof typedEntityName, keyof QueryIO[typeof typedEntityName]['input']>;
+
+        const processed = this.processFilter(typedEntityName, argName, argValues);
+        if (processed) acc.push(processed);
+        
+        return acc;
+      }, [])
+      .join(', ');
+    // Handle edge case: don't include empty parentheses when args is empty
+    const filtersForQuery = filterArgs ? `(${filterArgs})` : '';
+
+    const queryForEntity = `${String(entityName)}${filtersForQuery} {
+      ${fields.join('\n                ')}
+    }`;
+
+    return queryForEntity;
+  }
+
+  build<T extends QueryInput>(input: T & Record<Exclude<keyof T, keyof QueryInput>, never>): string {
+    const entities = Object.entries(input);
+    const queryStr = `
+      query {
+        ${entities
+          .map(([entity, filtersForQuery]) => {
+            const entityName = entity as keyof QueryIO;
+            const filters = filtersForQuery as QueryIO[typeof entityName]['input'] 
+            const parsedQuery = this.parseEntityQuery({ 
+              entityName,
+              filters
+            });
+            return parsedQuery;
+          }).join('\n          ')}
+      }  
+      `;
+    return queryStr
+  }
+}

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -31,7 +31,7 @@ describe('Subsquid Client', async (t) => {
   // Create a client for the query tests
   const client = new SubsquidClient('ethereum');
 
-  // // Test basic query functionality]
+  // Test basic query functionality]
   it('Should execute basic query without filters', async () => {
     const { tokens } = await client.query({
       tokens: {
@@ -167,7 +167,7 @@ describe('Subsquid Client', async (t) => {
     }
   });
 
-  // // // // Test OR conditions
+  // Test OR conditions
   it('Should query with OR conditions', async () => {
     try {
       const { tokens } = await client.query(
@@ -197,7 +197,7 @@ describe('Subsquid Client', async (t) => {
     }
   });
 
-  // // // Test ordering
+  // Test ordering
   it('Should query with ordering', async () => {
     try {
       const { tokens } = await client.query({
@@ -224,7 +224,7 @@ describe('Subsquid Client', async (t) => {
     }
   });
 
-  // // // Test different entity types
+  // Test different entity types
   it('Should query different entity types', async () => {
     try {
       const { transactions } = await client.query({
@@ -249,7 +249,7 @@ describe('Subsquid Client', async (t) => {
     }
   });
 
-  // // // Test filtering on other entity types
+  // Test filtering on other entity types
   it('Should query transactions with blockNumber filter', async () => {
     try {
       const blockThreshold = '14760000';

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -391,4 +391,48 @@ describe('Subsquid Client', async (t) => {
       assert.fail(`Mixed conditions query failed: ${error.message}`);
     }
   });
+
+  it('Should execute commitments connection query with pagination', async () => {
+    try {
+      const query = `
+        query {
+          commitmentsConnection(orderBy: id_ASC, after: "10", first: 10) {
+            edges {
+              cursor
+              node {
+                batchStartTreePosition
+              }
+            }
+            pageInfo {
+              hasNextPage
+            }
+          }
+        }
+      `;
+
+      const result = await client.request(query);
+      
+      assert.ok(result, 'Connection query should return a result');
+      assert.ok('commitmentsConnection' in result, 'Result should have commitmentsConnection property');
+      
+      const { commitmentsConnection } = result;
+      
+      assert.ok('edges' in commitmentsConnection, 'Connection should have edges property');
+      assert.ok(Array.isArray(commitmentsConnection.edges), 'Edges should be an array');
+      
+      assert.ok('pageInfo' in commitmentsConnection, 'Connection should have pageInfo property');
+      assert.ok('hasNextPage' in commitmentsConnection.pageInfo, 'PageInfo should have hasNextPage property');
+      
+      if (commitmentsConnection.edges.length > 0) {
+        const firstEdge = commitmentsConnection.edges[0];
+        
+        assert.ok('cursor' in firstEdge, 'Edge should have cursor property');
+        assert.ok('node' in firstEdge, 'Edge should have node property');
+        
+        assert.ok('batchStartTreePosition' in firstEdge.node, 'Node should have batchStartTreePosition property');
+      }
+    } catch (error) {
+      assert.fail(`Commitments connection query failed: ${error.message}`);
+    }
+  });
 });


### PR DESCRIPTION
  ## Enable Raw GraphQL String Requests for SubsquidClient

Exposes the `.request()` method publicly, allowing developers to execute raw GraphQL query strings directly. All in all it provides more flexibility for complex query scenarios (such as connection patterns with pagination). 

  ### What

  - reverts changes from  #9
  - makes the previously private `request()` method public
  - adds tests for the `.request()` method, including connection queries
  - updates documentation with usage examples

  ### Notes

  While offering more flexibility, the `.request()` method doesn't provide the same type safety as the structured query builder. Developers should use this method with care and ensure proper GraphQL syntax in their queries.
