### PR TITLE
Feat: update to const typed parameters 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ When initializing the client, you can either use a predefined network or provide
 
 ### Basic Usage
 
-**Important:** When defining field arrays, always use `as const` to ensure proper type inference, especially for nested queries. This preserves the exact types of fields selected and enables complete type safety.
-
 ```ts
 import { SubsquidClient, TokenType } from '@railgun-reloaded/subsquid-client';
 
@@ -39,7 +37,7 @@ const customClient = new SubsquidClient({ customSubsquidUrl: 'https://my-subsqui
 // Simple query for tokens with type-safety
 const { tokens } = await client.query({
   tokens: {
-    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
     limit: 5
   }
 });
@@ -51,15 +49,15 @@ const { tokens } = await client.query({
 // Query multiple entity types in a single request
 const { tokens, commitments, nullifiers } = await client.query({
   tokens: {
-    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
     limit: 5
   },
   commitments: {
-    fields: ['id', 'transactionHash', 'treeNumber', 'batchStartTreePosition'] as const,
+    fields: ['id', 'transactionHash', 'treeNumber', 'batchStartTreePosition'],
     limit: 5
   },
   nullifiers: {
-    fields: ['id', 'nullifier', 'transactionHash', 'treeNumber'] as const,
+    fields: ['id', 'nullifier', 'transactionHash', 'treeNumber'],
     limit: 5
   }
 });
@@ -71,7 +69,7 @@ const { tokens, commitments, nullifiers } = await client.query({
 // Filter tokens by ERC20 type
 const { tokens } = await client.query({
   tokens: {
-    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
     limit: 5,
     where: {
       tokenType_eq: TokenType.Erc20
@@ -86,7 +84,7 @@ const { tokens } = await client.query({
 // Find tokens that are either ERC20 or ERC721
 const { tokens } = await client.query({
   tokens: {
-    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
     limit: 5,
     where: {
       OR: [{ tokenType_eq: TokenType.Erc20 }, { tokenType_eq: TokenType.Erc721 }]
@@ -101,7 +99,7 @@ const { tokens } = await client.query({
 // Complex nested where conditions
 const { tokens } = await client.query({
   tokens: {
-    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
     limit: 10,
     where: {
       AND: [
@@ -126,10 +124,10 @@ const { unshields } = await client.query({
   unshields: {
     fields: [
       'id',
-      { token: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] } as const,
+      { token: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] },
       'amount',
       'blockNumber'
-    ] as const,
+    ],
     limit: 5
   }
 });
@@ -141,7 +139,7 @@ const { unshields } = await client.query({
 // Order tokens by ID ascending
 const { tokens } = await client.query({
   tokens: {
-    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+    fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
     limit: 5,
     orderBy: ['id_ASC']
   }
@@ -154,7 +152,7 @@ const { tokens } = await client.query({
 // Filter transactions by block number
 const { transactions } = await client.query({
   transactions: {
-    fields: ['id', 'blockNumber', 'transactionHash'] as const,
+    fields: ['id', 'blockNumber', 'transactionHash'],
     limit: 5,
     where: {
       blockNumber_gt: '14760000'

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@railgun-reloaded/eslint-config": "^1.1.0",
     "@railgun-reloaded/tsconfig": "^1.2.0",
     "@types/node": "^22.13.10",
-    "eslint": "^9.22.0"
+    "eslint": "^9.22.0",
+    "typescript": "^5.0.0"
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -101,7 +101,7 @@ export class SubsquidClient {
    * @param input - The query input to build and execute
    * @returns Promise that resolves to the query result
    */
-  async query<T extends QueryInput> (
+  async query<const T extends QueryInput> (
     input: StrictQueryInput<T>
   ): Promise<QueryOutput<T>> {
     const queryStr = queryBuilder.build(input)

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -72,7 +72,7 @@ describe('Subsquid Client', async (t) => {
   it('Should execute basic query without filters', async () => {
     const { tokens } = await client.query({
       tokens: {
-        fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+        fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
         limit: 5,
       }
     })
@@ -90,19 +90,19 @@ describe('Subsquid Client', async (t) => {
   it('Should execute basic query for several entities', async () => {
     const { tokens, commitments, nullifiers, transactions } = await client.query({
       tokens: {
-        fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+        fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
         limit: 5,
       },
       commitments: {
-        fields: ['id', 'transactionHash', 'treeNumber', 'batchStartTreePosition'] as const,
+        fields: ['id', 'transactionHash', 'treeNumber', 'batchStartTreePosition'],
         limit: 5,
       },
       nullifiers: {
-        fields: ['id', 'nullifier', 'transactionHash', 'treeNumber'] as const,
+        fields: ['id', 'nullifier', 'transactionHash', 'treeNumber'],
         limit: 5,
       },
       transactions: {
-        fields: ['id', 'blockNumber', 'transactionHash'] as const,
+        fields: ['id', 'blockNumber', 'transactionHash'],
         limit: 5,
       }
     })
@@ -147,7 +147,7 @@ describe('Subsquid Client', async (t) => {
       const { tokens } = await client.query(
         {
           tokens: {
-            fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+            fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
             limit: 5,
             where: {
               tokenType_eq: TokenType.Erc20
@@ -171,7 +171,7 @@ describe('Subsquid Client', async (t) => {
       const { tokens } = await client.query(
         {
           tokens: {
-            fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+            fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
             limit: 10,
             where: {
               AND: [
@@ -211,10 +211,10 @@ describe('Subsquid Client', async (t) => {
       unshields: {
         fields: [
           'id',
-          { token: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] } as const,
+          { token: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] },
           'amount',
           'blockNumber'
-        ] as const,
+        ],
         limit: 5,
       }
     })
@@ -244,7 +244,7 @@ describe('Subsquid Client', async (t) => {
       const { tokens } = await client.query(
         {
           tokens: {
-            fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+            fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
             limit: 5,
             where: {
               OR: [{ tokenType_eq: TokenType.Erc20 }, { tokenType_eq: TokenType.Erc721 }],
@@ -272,7 +272,7 @@ describe('Subsquid Client', async (t) => {
     try {
       const { tokens } = await client.query({
         tokens: {
-          fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'] as const,
+          fields: ['id', 'tokenType', 'tokenAddress', 'tokenSubID'],
           limit: 5,
           orderBy: ['id_ASC']
         }
@@ -297,7 +297,7 @@ describe('Subsquid Client', async (t) => {
     try {
       const { transactions } = await client.query({
         transactions: {
-          fields: ['id', 'blockNumber', 'transactionHash'] as const,
+          fields: ['id', 'blockNumber', 'transactionHash'],
           limit: 5,
         }
       })
@@ -322,7 +322,7 @@ describe('Subsquid Client', async (t) => {
       const blockThreshold = '14760000'
       const { transactions } = await client.query({
         transactions: {
-          fields: ['id', 'blockNumber', 'transactionHash'] as const,
+          fields: ['id', 'blockNumber', 'transactionHash'],
           limit: 5,
           where: {
             blockNumber_gt: blockThreshold


### PR DESCRIPTION
As per https://github.com/railgun-reloaded/subsquid-client/pull/21, we did introduce `as const` to prevent [type widening](https://dozie.dev/type-widening-in-typescript). 

But from release notes on [typescript 5.0](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#const-type-parameters), we can now make usage of const typed parameters. 

This PR introduces a refactor to replace our previous implementation and leverage TypeScript 5.0's native const type parameters.

<img width="744" alt="image" src="https://github.com/user-attachments/assets/d0149da0-ee08-4be0-95d6-4f956f8cb52f" />
