### PR TITLE
Fix: Precedence for custom url over network

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -26,15 +26,6 @@ export class SubsquidClient {
    * @returns The Subsquid URL to use
    */
   private getSubsquidUrl (options: SubsquidClientOptions): string {
-    if ('network' in options) {
-      const networkUrl = NETWORK_CONFIG[options.network as keyof typeof NETWORK_CONFIG]
-      if (!networkUrl) {
-        throw new Error(
-          `Unsupported network: ${options.network}. Supported networks are: ${SUPPORTED_NETWORKS.join(', ')}`
-        )
-      }
-      return networkUrl
-    }
     if ('customSubsquidUrl' in options) {
       const { customSubsquidUrl } = options
       if (!customSubsquidUrl || customSubsquidUrl.trim() === '') {
@@ -47,6 +38,15 @@ export class SubsquidClient {
       } catch (error) {
         throw new Error(`Invalid URL format: ${customSubsquidUrl}`)
       }
+    }
+    if ('network' in options) {
+      const networkUrl = NETWORK_CONFIG[options.network as keyof typeof NETWORK_CONFIG]
+      if (!networkUrl) {
+        throw new Error(
+          `Unsupported network: ${options.network}. Supported networks are: ${SUPPORTED_NETWORKS.join(', ')}`
+        )
+      }
+      return networkUrl
     }
     throw new Error(
       'Invalid configuration. Provide either { network } or { customSubsquidUrl }.'

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -34,6 +34,14 @@ describe('Subsquid Client', async (t) => {
     assert.throws(() => new SubsquidClient({ network: invalid as any }))
   })
 
+  it('Should use customSubsquidUrl if both customSubsquidUrl and network are provided', () => {
+    const TEST_URL = 'https://custom.example.com/graphql'
+    const TEST_NETWORK = 'ethereum'
+    const client = new SubsquidClient({ customSubsquidUrl: TEST_URL, network: TEST_NETWORK } as any)
+    // @ts-expect-error: accessing private property for test
+    assert.strictEqual(client.clientUrl, TEST_URL, 'customSubsquidUrl should take precedence over network')
+  })
+
   const client = new SubsquidClient({ network: 'ethereum' })
 
   it('Should throw an error when GraphQL response contains errors from invalid syntax', async () => {


### PR DESCRIPTION
make customSubsquidUrl take precedence over network

If both customSubsquidUrl and network are provided, the client now always uses customSubsquidUrl.

adds a test to ensure this precedence, this makes the config behavior more intuitive.